### PR TITLE
Add reset button to search bar

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -46,6 +46,20 @@ const SearchBar: React.FC<SearchBarProps> = ({
             ))}
           </select>
         </div>
+
+        {/* Reset Button */}
+        <div className="flex items-center">
+          <button
+            type="button"
+            onClick={() => {
+              onSearchChange('');
+              onCategoryChange('');
+            }}
+            className="bg-gray-200 text-gray-700 px-4 py-3 rounded-lg hover:bg-gray-300 transition-colors"
+          >
+            Réinitialiser
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a Reset button in `SearchBar` to clear search filters

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847014ba284832eaa24c32ddb713147