### PR TITLE
Add manifest and simple service worker

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="./vite.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EchoGIS1 - FAQ Personnel GIS 1</title>
     <meta name="description" content="Foire aux questions pour le personnel du GIS 1. Consultez les réponses aux questions fréquentes et soumettez vos propres questions." />
@@ -11,5 +13,12 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js');
+        });
+      }
+    </script>
   </body>
 </html>

--- a/docs/manifest.webmanifest
+++ b/docs/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "EchoGIS1",
+  "short_name": "EchoGIS1",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "description": "Foire aux questions pour le personnel du GIS 1.",
+  "icons": [
+    {
+      "src": "/vite.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,0 +1,19 @@
+const CACHE_NAME = 'echogis-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+  '/vite.svg'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/docs/vite.svg
+++ b/docs/vite.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="blue"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="./vite.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EchoGIS1 - FAQ Personnel GIS 1</title>
     <meta name="description" content="Foire aux questions pour le personnel du GIS 1. Consultez les réponses aux questions fréquentes et soumettez vos propres questions." />

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vite-plugin-pwa": "^0.18.0"
   }
 }

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "EchoGIS1",
+  "short_name": "EchoGIS1",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "description": "Foire aux questions pour le personnel du GIS 1.",
+  "icons": [
+    {
+      "src": "/vite.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,19 @@
+const CACHE_NAME = 'echogis-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+  '/vite.svg'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/public/vite.svg
+++ b/public/vite.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="blue"/>
+</svg>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,4 +7,10 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>
-);
+  );
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    VitePWA({ registerType: 'autoUpdate' }),
+  ],
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- add `vite-plugin-pwa` to dev dependencies and enable it
- create web manifest and dummy icon
- implement simple service worker with basic caching
- link manifest and theme color in html
- register service worker in app
- update built `docs` files to ship the manifest and service worker

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847015d6524832ea88355138c032225