### PR TITLE
Enable dark theme with toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Cette application vise à :
 - Extraire automatiquement les Q/R depuis des PV Word ou PDF
 - Afficher dynamiquement les dates à venir des réunions de CPUE
 - Être utilisée localement sans base de données ni droits administrateur
+- Proposer un thème sombre activable depuis l'en-tête
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <Header 
         meetingDates={data.settings.meetingDates} 
         isAdmin={isAdmin}

--- a/src/components/AdminLogin.tsx
+++ b/src/components/AdminLogin.tsx
@@ -21,18 +21,18 @@ const AdminLogin: React.FC<AdminLoginProps> = ({ onLogin, onCancel }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl p-8 max-w-md w-full mx-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-8 max-w-md w-full mx-4">
         <div className="text-center mb-6">
           <div className="bg-red-600 p-3 rounded-full w-16 h-16 mx-auto mb-4">
             <Shield className="h-10 w-10 text-white" />
           </div>
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">Mode Administrateur</h2>
-          <p className="text-gray-600">Veuillez saisir le code d'accès administrateur</p>
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">Mode Administrateur</h2>
+          <p className="text-gray-600 dark:text-gray-300">Veuillez saisir le code d'accès administrateur</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label htmlFor="adminCode" className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="adminCode" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               Code administrateur
             </label>
             <div className="relative">
@@ -45,7 +45,7 @@ const AdminLogin: React.FC<AdminLoginProps> = ({ onLogin, onCancel }) => {
                   setCode(e.target.value);
                   setError('');
                 }}
-                className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent"
+              className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
                 placeholder="Saisissez le code"
                 autoFocus
               />
@@ -59,7 +59,7 @@ const AdminLogin: React.FC<AdminLoginProps> = ({ onLogin, onCancel }) => {
             <button
               type="button"
               onClick={onCancel}
-              className="flex-1 bg-gray-200 text-gray-700 py-3 px-4 rounded-lg font-medium hover:bg-gray-300 transition-colors"
+              className="flex-1 bg-gray-200 text-gray-700 py-3 px-4 rounded-lg font-medium hover:bg-gray-300 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
             >
               Annuler
             </button>
@@ -72,7 +72,7 @@ const AdminLogin: React.FC<AdminLoginProps> = ({ onLogin, onCancel }) => {
           </div>
         </form>
 
-        <div className="mt-6 text-center text-sm text-gray-500">
+        <div className="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
           <p>Code par défaut: pompiers</p>
         </div>
       </div>

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -172,17 +172,17 @@ const AdminPanel: React.FC<AdminPanelProps> = ({ data, onDataChange }) => {
   const categories = Array.from(new Set(data.faqs.map(faq => faq.category)));
 
   return (
-    <div className="bg-white rounded-lg shadow-sm">
+    <div className="bg-white dark:bg-gray-800 dark:text-gray-100 rounded-lg shadow-sm">
       {/* Admin Header */}
-      <div className="border-b border-gray-200 p-6">
+      <div className="border-b border-gray-200 dark:border-gray-700 p-6">
         <div className="flex items-center space-x-3">
           <Settings className="h-6 w-6 text-red-600" />
-          <h2 className="text-xl font-semibold text-gray-900">Administration</h2>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Administration</h2>
         </div>
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-gray-200">
+      <div className="border-b border-gray-200 dark:border-gray-700">
         <nav className="flex space-x-8 px-6">
           {[
             { id: 'faqs', label: 'Gestion FAQ', icon: Plus },

--- a/src/components/FAQList.tsx
+++ b/src/components/FAQList.tsx
@@ -11,7 +11,7 @@ const FAQList: React.FC<FAQListProps> = ({ faqs }) => {
     return (
       <div className="text-center py-12">
         <MessageCircle className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-        <p className="text-gray-600">Aucune question trouvée avec ces critères.</p>
+        <p className="text-gray-600 dark:text-gray-300">Aucune question trouvée avec ces critères.</p>
       </div>
     );
   }
@@ -19,13 +19,13 @@ const FAQList: React.FC<FAQListProps> = ({ faqs }) => {
   return (
     <div className="space-y-6">
       {faqs.map((faq) => (
-        <div key={faq.id} className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        <div key={faq.id} className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
           <div className="p-6">
             <div className="flex items-start justify-between mb-4">
-              <h3 className="text-lg font-semibold text-gray-900 flex-1 pr-4">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 flex-1 pr-4">
                 {faq.question}
               </h3>
-              <div className="flex items-center space-x-2 text-sm text-gray-500">
+              <div className="flex items-center space-x-2 text-sm text-gray-500 dark:text-gray-400">
                 <Tag className="h-4 w-4" />
                 <span className="bg-red-100 text-red-800 px-2 py-1 rounded-full">
                   {faq.category}
@@ -33,7 +33,7 @@ const FAQList: React.FC<FAQListProps> = ({ faqs }) => {
               </div>
             </div>
             
-            <div className="prose prose-sm max-w-none text-gray-700 mb-4">
+            <div className="prose prose-sm max-w-none text-gray-700 dark:text-gray-300 mb-4">
               {faq.answer.split('\n').map((paragraph, index) => (
                 <p key={index} className="mb-2 last:mb-0">
                   {paragraph}
@@ -41,7 +41,7 @@ const FAQList: React.FC<FAQListProps> = ({ faqs }) => {
               ))}
             </div>
 
-            <div className="flex items-center justify-between text-xs text-gray-500 pt-4 border-t border-gray-100">
+            <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400 pt-4 border-t border-gray-100 dark:border-gray-700">
               <div className="flex items-center space-x-4">
                 <div className="flex items-center space-x-1">
                   <Calendar className="h-3 w-3" />
@@ -59,7 +59,7 @@ const FAQList: React.FC<FAQListProps> = ({ faqs }) => {
                   {faq.keywords.map((keyword, index) => (
                     <span
                       key={index}
-                      className="bg-gray-100 text-gray-600 px-2 py-0.5 rounded text-xs"
+                      className="bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-200 px-2 py-0.5 rounded text-xs"
                     >
                       {keyword}
                     </span>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Calendar, Shield } from 'lucide-react';
 import { MeetingDate } from '../types';
 
@@ -9,13 +9,28 @@ interface HeaderProps {
 }
 
 const Header: React.FC<HeaderProps> = ({ meetingDates, isAdmin, onToggleAdmin }) => {
+  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'light');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  };
   const upcomingMeetings = meetingDates
     .filter(meeting => new Date(meeting.date) >= new Date())
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
     .slice(0, 3);
 
   return (
-    <header className="bg-white shadow-sm">
+    <header className="bg-white dark:bg-gray-800 shadow-sm">
       {/* Meeting Dates Banner */}
       {upcomingMeetings.length > 0 && (
         <div className="bg-red-600 text-white py-2">
@@ -42,21 +57,29 @@ const Header: React.FC<HeaderProps> = ({ meetingDates, isAdmin, onToggleAdmin })
               <Shield className="h-8 w-8 text-white" />
             </div>
             <div>
-              <h1 className="text-3xl font-bold text-gray-900">EchoGIS1</h1>
-              <p className="text-gray-600">Foire aux questions - Personnel GIS 1</p>
+              <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">EchoGIS1</h1>
+              <p className="text-gray-600 dark:text-gray-300">Foire aux questions - Personnel GIS 1</p>
             </div>
           </div>
-          
-          <button
-            onClick={onToggleAdmin}
-            className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-              isAdmin
-                ? 'bg-red-600 text-white hover:bg-red-700'
-                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-            }`}
-          >
-            {isAdmin ? 'Mode Admin' : 'Mode Utilisateur'}
-          </button>
+
+          <div className="flex items-center space-x-2">
+            <button
+              onClick={toggleTheme}
+              className="px-4 py-2 rounded-lg font-medium transition-colors bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              {theme === 'dark' ? 'Clair' : 'Sombre'}
+            </button>
+            <button
+              onClick={onToggleAdmin}
+              className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                isAdmin
+                  ? 'bg-red-600 text-white hover:bg-red-700'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+              }`}
+            >
+              {isAdmin ? 'Mode Admin' : 'Mode Utilisateur'}
+            </button>
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -37,11 +37,11 @@ const QuestionForm: React.FC<QuestionFormProps> = ({ companies, contactEmail }) 
 
   if (isSubmitted) {
     return (
-      <div className="bg-white rounded-lg shadow-sm p-8">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-8">
         <div className="text-center">
           <CheckCircle className="h-16 w-16 text-green-600 mx-auto mb-4" />
-          <h3 className="text-xl font-semibold text-gray-900 mb-2">Question envoyée !</h3>
-          <p className="text-gray-600">
+          <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Question envoyée !</h3>
+          <p className="text-gray-600 dark:text-gray-300">
             Votre question a été transmise à l'équipe administrative. 
             Vous recevrez une réponse dans les plus brefs délais.
           </p>
@@ -51,23 +51,23 @@ const QuestionForm: React.FC<QuestionFormProps> = ({ companies, contactEmail }) 
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-sm p-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
       <div className="flex items-center space-x-3 mb-6">
         <Mail className="h-6 w-6 text-red-600" />
-        <h2 className="text-xl font-semibold text-gray-900">Poser une question</h2>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Poser une question</h2>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-6">
         {/* Company Selection */}
         <div>
-          <label htmlFor="company" className="block text-sm font-medium text-gray-700 mb-2">
+          <label htmlFor="company" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
             Compagnie d'affectation *
           </label>
           <select
             id="company"
             value={formData.company}
             onChange={(e) => setFormData({ ...formData, company: e.target.value })}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
             required
           >
             <option value="">Sélectionnez votre compagnie</option>
@@ -81,7 +81,7 @@ const QuestionForm: React.FC<QuestionFormProps> = ({ companies, contactEmail }) 
 
         {/* Question Input */}
         <div>
-          <label htmlFor="question" className="block text-sm font-medium text-gray-700 mb-2">
+          <label htmlFor="question" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
             Votre question *
           </label>
           <textarea
@@ -90,7 +90,7 @@ const QuestionForm: React.FC<QuestionFormProps> = ({ companies, contactEmail }) 
             value={formData.question}
             onChange={(e) => setFormData({ ...formData, question: e.target.value })}
             placeholder="Décrivez votre question de manière détaillée..."
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent resize-vertical"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent resize-vertical dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
             required
           />
         </div>
@@ -105,7 +105,7 @@ const QuestionForm: React.FC<QuestionFormProps> = ({ companies, contactEmail }) 
         </button>
       </form>
 
-      <div className="mt-4 text-sm text-gray-500">
+      <div className="mt-4 text-sm text-gray-500 dark:text-gray-400">
         <p>* Champs obligatoires</p>
         <p>Votre question sera envoyée par e-mail à l'équipe administrative.</p>
       </div>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -17,7 +17,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   categories
 }) => {
   return (
-    <div className="bg-white p-6 rounded-lg shadow-sm mb-6">
+    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm mb-6">
       <div className="flex flex-col lg:flex-row gap-4">
         {/* Search Input */}
         <div className="flex-1 relative">
@@ -27,7 +27,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
             placeholder="Rechercher une question..."
             value={searchTerm}
             onChange={(e) => onSearchChange(e.target.value)}
-            className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent"
+            className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
           />
         </div>
 
@@ -36,7 +36,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
           <select
             value={selectedCategory}
             onChange={(e) => onCategoryChange(e.target.value)}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
           >
             <option value="">Toutes les catégories</option>
             {categories.map(category => (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind
- persist theme choice with a new toggle button in the header
- style pages using `dark:` classes
- document the new dark mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68470160dbf4832e83cc69adf0563b33