### PR TITLE
Add tests and CI

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -30,6 +31,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/utils/__tests__/parseQuestionsFromText.test.ts
+++ b/src/utils/__tests__/parseQuestionsFromText.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { parseQuestionsFromText } from '../fileProcessing';
+
+describe('parseQuestionsFromText', () => {
+  it('parses simple Q and R format', () => {
+    const text = `Q: Quelle est la procédure pour les demandes de congés ?\nR: Les demandes doivent être effectuées via le formulaire dédié au moins 15 jours à l\u0027avance.`;
+    const result = parseQuestionsFromText(text);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      question: 'Quelle est la procédure pour les demandes de congés ?',
+      answer: 'Les demandes doivent être effectuées via le formulaire dédié au moins 15 jours à l\u0027avance.'
+    });
+  });
+
+  it('parses Question/Réponse format', () => {
+    const text = `Question: Comment accéder aux plannings de service ?\nRéponse: Les plannings sont disponibles sur l\u0027intranet dans la section \"Plannings\".`;
+    const result = parseQuestionsFromText(text);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      question: 'Comment accéder aux plannings de service ?',
+      answer: 'Les plannings sont disponibles sur l\u0027intranet dans la section "Plannings".'
+    });
+  });
+
+  it('parses numbered list format', () => {
+    const text = `1. Pourquoi le ciel est-il bleu ?\nParce que la lumière se diffuse dans l\u0027atmosphère.\n2. Qu\u0027est-ce que Vitest ?\nVitest est un framework de test rapide pour Vite.`;
+    const result = parseQuestionsFromText(text);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      question: 'Pourquoi le ciel est-il bleu ?',
+      answer: 'Parce que la lumière se diffuse dans l\u0027atmosphère.'
+    });
+    expect(result[1]).toEqual({
+      question: "Qu'est-ce que Vitest ?",
+      answer: 'Vitest est un framework de test rapide pour Vite.'
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest setup with sample tests
- add GitHub Actions workflow to run lint, build and tests

## Testing
- `npm run lint` *(fails: command not found)*
- `npm run build` *(fails: command not found)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684701711b84832eb91d1d759bff0d21