### PR TITLE
Add backup restore and merged JSON imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { loadData, saveData } from './utils/storage';
+import { loadData, saveData, importData } from './utils/storage';
 import { AppData } from './types';
 import Header from './components/Header';
 import SearchBar from './components/SearchBar';
@@ -7,6 +7,7 @@ import FAQList from './components/FAQList';
 import QuestionForm from './components/QuestionForm';
 import AdminPanel from './components/AdminPanel';
 import AdminLogin from './components/AdminLogin';
+import RestoreModal from './components/RestoreModal';
 
 function App() {
   const [data, setData] = useState<AppData>(loadData());
@@ -15,6 +16,7 @@ function App() {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('');
   const [activeView, setActiveView] = useState<'faq' | 'submit' | 'admin'>('faq');
+  const [showRestoreModal, setShowRestoreModal] = useState(true);
 
   // Save data whenever it changes
   useEffect(() => {
@@ -63,6 +65,12 @@ function App() {
 
   const handleDataChange = (newData: AppData) => {
     setData(newData);
+  };
+
+  const handleRestoreFile = async (file: File) => {
+    const newData = await importData(file);
+    setData(newData);
+    setShowRestoreModal(false);
   };
 
   return (
@@ -136,6 +144,13 @@ function App() {
         <AdminLogin
           onLogin={handleAdminLogin}
           onCancel={() => setShowAdminLogin(false)}
+        />
+      )}
+
+      {showRestoreModal && (
+        <RestoreModal
+          onFileSelect={handleRestoreFile}
+          onCancel={() => setShowRestoreModal(false)}
         />
       )}
     </div>

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -101,7 +101,9 @@ const AdminPanel: React.FC<AdminPanelProps> = ({ data, onDataChange }) => {
       } else if (file.name.endsWith('.pdf')) {
         text = await extractTextFromPdf(file);
       } else if (file.name.endsWith('.json')) {
-        await importData(file);
+        const merged = await importData(file);
+        const backupName = exportData(merged);
+        alert(`Sauvegarde créée: ${backupName}`);
         window.location.reload();
         return;
       } else {

--- a/src/components/RestoreModal.tsx
+++ b/src/components/RestoreModal.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+interface RestoreModalProps {
+  onFileSelect: (file: File) => void;
+  onCancel: () => void;
+}
+
+const RestoreModal: React.FC<RestoreModalProps> = ({ onFileSelect, onCancel }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      onFileSelect(file);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 max-w-sm w-full">
+        <h2 className="text-lg font-semibold mb-4">Charger une sauvegarde ?</h2>
+        <input
+          type="file"
+          accept=".json"
+          onChange={handleChange}
+          className="mb-4"
+        />
+        <div className="flex justify-end space-x-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="bg-gray-200 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-300"
+          >
+            Ignorer
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RestoreModal;


### PR DESCRIPTION
## Summary
- merge new questions from JSON imports with existing ones
- export backup automatically after import
- add RestoreModal prompting to load a backup on start
- prompt when importing JSON in admin panel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684712cca5e8832ea0d9cd980686664b