### PR TITLE
feat: import JSON list format

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,10 @@ Cette application vise à :
  ┣ 📜 README.md           # Cette documentation
  ┗ 📜 LICENSE.txt         # Licence open source
 
+## Importer un fichier JSON
 
+Vous pouvez importer une liste de questions/réponses au format JSON via
+l'onglet **Import/Export** de l'interface administrateur. Le fichier doit
+contenir un tableau d'objets avec les propriétés `question`, `réponse` et
+`compagnie` (voir `docs/import.json`). Les entrées importées sont ajoutées
+aux FAQ existantes et une sauvegarde automatique est créée.

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -102,9 +102,9 @@ const AdminPanel: React.FC<AdminPanelProps> = ({ data, onDataChange }) => {
         text = await extractTextFromPdf(file);
       } else if (file.name.endsWith('.json')) {
         const merged = await importData(file);
+        onDataChange(merged);
         const backupName = exportData(merged);
         alert(`Sauvegarde créée: ${backupName}`);
-        window.location.reload();
         return;
       } else {
         alert('Format de fichier non supporté. Utilisez .docx, .pdf ou .json');

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -109,12 +109,31 @@ export const importData = (file: File): Promise<AppData> => {
     const reader = new FileReader();
     reader.onload = (e) => {
       try {
-        const imported = JSON.parse(e.target?.result as string) as AppData;
+        const parsed = JSON.parse(e.target?.result as string);
         const current = loadData();
+
+        let importedFaqs: FAQ[] = [];
+        let importedData: Partial<AppData> = {};
+
+        if (Array.isArray(parsed)) {
+          importedFaqs = parsed.map((item, idx) => ({
+            id: `import-${Date.now()}-${idx}`,
+            question: item.question ?? item.Question ?? '',
+            answer: item.answer ?? item.réponse ?? item.Réponse ?? '',
+            category: item.compagnie ?? item.category ?? 'Importé',
+            keywords: [],
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString()
+          }));
+        } else {
+          importedData = parsed as AppData;
+          importedFaqs = (importedData.faqs ?? []) as FAQ[];
+        }
+
         const merged: AppData = {
           ...current,
-          ...imported,
-          faqs: [...current.faqs, ...(imported.faqs || [])]
+          ...importedData,
+          faqs: [...current.faqs, ...importedFaqs]
         };
         saveData(merged);
         resolve(merged);


### PR DESCRIPTION
## Summary
- support importing JSON arrays into FAQ data
- update admin import logic to save directly
- document JSON import format

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68471ec698cc832eace49a9ce5e60a74